### PR TITLE
Fix parsing nested strings.

### DIFF
--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -29,6 +29,8 @@ function undollar(node) {
     if (Array.isArray(node)) {
         if (node.length === 1 && Object.keys(node[0]).length === 0) {
             return node[0];
+        } else if (node.length == 1 && typeof node[0] === 'string') {
+            return node[0];
         } else if (node.length > 1) {
             return node.map(element => undollar(element));
         } else {
@@ -41,6 +43,10 @@ function undollar(node) {
                     .reduce((prev, cur) => prev + cur)
                     .trim();
         }
+    }
+
+    if (typeof node === 'string') {
+      return node;
     }
 
     Object.keys(node).forEach(key => {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -80,6 +80,40 @@ describe("xml report parser", () => {
             });
     });
 
+    it("parseXMLString() - failed3.xml", done => {
+
+        const s = fs.readFileSync(path.join(__dirname, "resources", "failed3.xml"));
+
+        new Parser({modifier: (xmlObject) => {
+          expect(xmlObject.testsuites.testsuite[1].testcase[0].failure).equal('single failure');
+          expect(xmlObject.testsuites.testsuite[1].testcase[1].failure[0]).equal('1st failure');
+          expect(xmlObject.testsuites.testsuite[1].testcase[1].failure[1]).equal('2nd failure');
+          return xmlObject;
+        }}).parseXMLString(s)
+            .then(r => {
+                expect(r.testsuites.length).equal(3);
+
+                expect(r.testsuites[0].succeeded).equal(1);
+                expect(r.testsuites[0].tests).equal(1);
+                expect(r.testsuites[0].errors).equal(0);
+                expect(r.testsuites[0].skipped).equal(0);
+
+                expect(r.testsuites[1].succeeded).equal(0);
+                expect(r.testsuites[1].tests).equal(1);
+                expect(r.testsuites[1].errors).equal(1);
+                expect(r.testsuites[1].skipped).equal(0);
+
+                expect(r.testsuites[1].succeeded).equal(0);
+                expect(r.testsuites[1].tests).equal(1);
+                expect(r.testsuites[1].errors).equal(1);
+                expect(r.testsuites[1].skipped).equal(0);
+                done();
+            })
+            .catch(e => {
+                done(e);
+            });
+    });
+
     it("parseXMLString() - passed.xml", done => {
 
         const s = fs.readFileSync(path.join(__dirname, "resources", "passed.xml"));
@@ -243,7 +277,7 @@ describe("xml report parser", () => {
                 expect(r.testsuites[7].name).equal("args");
                 expect(r.testsuites[8].name).equal("args2");
 
-                expect(new Date(r.testsuites[0].timestamp).getTime()).equal(1512662456000);
+                expect(new Date(r.testsuites[0].timestamp).getTime()).equal(1512694856000);
                 expect(r.testsuites[0].properties.length).equal(1);
 
                 for (const x of r.testsuites) {

--- a/test/resources/failed3.xml
+++ b/test/resources/failed3.xml
@@ -1,0 +1,15 @@
+<testsuites name="jest tests">
+  <testsuite name="addition.test.js" tests="1" errors="0" failures="0" skipped="0" timestamp="2017-07-13T09:42:28" time="0.161">
+    <testcase classname="addition positive numbers should add up" name="addition positive numbers should add up" time="0.004">
+    </testcase>
+  </testsuite>
+  <testsuite name="addition.failure.js" tests="1" errors="0" failures="2" skipped="0" timestamp="2017-07-13T09:42:28" time="0.161">
+    <testcase classname="single failure" name="addition positive numbers should add up" time="0.004">
+      <failure>single failure</failure>
+    </testcase>
+    <testcase classname="multiple failures" name="addition positive numbers should add up" time="0.004">
+      <failure>1st failure</failure>
+      <failure>2nd failure</failure>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This fixes an issue where string keys are iterated with `Object.keys` which caused problems when I was trying to add a modifier for the output of `jest-junit`.

I also modified a test that seems to be failing, but I can revert if it's just my timezone.

@ladariha, could you take a look?